### PR TITLE
Replace Express with native HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# chatgpt
+# LINE Course Registration Example
+
+This repository contains a simple example of how to implement a course registration API that could be used with a LINE bot or LIFF application.
+
+## Running the Server
+
+There are no external dependencies. Simply run:
+
+```bash
+node server/index.js
+```
+
+The API will listen on port `3000` by default.
+
+## Available Endpoints
+
+- `GET /api/courses` – List all courses.
+- `POST /api/courses/:id/register` – Register for a course. Send your LINE user ID in the `X-User-Id` header.
+- `GET /api/members/me/registrations` – View the registrations for the current user (identified by `X-User-Id`).
+
+This server uses Node's built-in `http` module and keeps data in memory for demonstration purposes.

--- a/docs/line_course_system_design.md
+++ b/docs/line_course_system_design.md
@@ -1,0 +1,59 @@
+# LINE互動王課程報名系統設計
+
+以下設計概述一個基於 LINE 互動王 的課程報名網站，讓 LINE 用戶能夠直接在 LINE 中查看課程資訊、報名並完成整個流程，並具備會員系統。
+
+## 1. 系統架構
+
+1. **前端**：採用 LIFF (LINE Front-end Framework)，透過 Web 技術 (HTML、CSS、JavaScript) 建立頁面，可直接在 LINE 內嵌瀏覽。
+2. **後端**：使用 Node.js + Express 來處理 API 與業務邏輯。
+3. **資料庫**：MySQL 或其他關聯式資料庫，儲存會員、課程以及報名紀錄。
+4. **LINE 機器人**：透過 LINE Messaging API 與用戶互動，導向 LIFF 頁面或推播課程資訊。
+
+## 2. 會員系統
+
+- 使用 LINE Login 或 LIFF 的 `liff.login()` 功能來取得用戶 LINE 身份。
+- 後端根據 LINE 使用者 ID 建立/查詢會員資料。
+- 會員資料範例欄位：
+  - `id` (PK)
+  - `line_user_id`
+  - `display_name`
+  - `email`
+  - `created_at`
+
+## 3. 課程管理
+
+- 課程資料表範例欄位：
+  - `id` (PK)
+  - `title`
+  - `description`
+  - `start_time`
+  - `end_time`
+  - `capacity`
+- 提供後台介面讓管理者新增/編輯課程。
+
+## 4. 報名流程
+
+1. 用戶進入 LIFF 頁面瀏覽課程列表。
+2. 點擊「報名」後，若尚未登入，先導向 LINE Login。
+3. 登入後於報名表單填寫必要資料（例如 email、電話）。
+4. 後端檢查課程名額並建立報名紀錄：
+   - `id` (PK)
+   - `member_id`
+   - `course_id`
+   - `status` (報名成功、候補等)
+5. 回傳結果於 LIFF 頁面顯示，並可透過 LINE bot 發送確認訊息。
+
+## 5. 其他功能建議
+
+- **報名管理**：會員可於 LIFF 頁面查看自己的報名紀錄與狀態。
+- **推播提醒**：課程開始前透過 LINE bot 發送提醒訊息。
+- **取消機制**：提供取消報名功能，並針對候補名單自動遞補。
+
+## 6. 範例 API 設計
+
+- `GET /api/courses`：取得課程列表。
+- `POST /api/courses/:id/register`：報名指定課程。
+- `GET /api/members/me/registrations`：取得登入會員的報名紀錄。
+
+以上為在 LINE 互動王上建置課程報名與會員系統的基本設計，可依需求擴充，例如整合金流付款、課程提醒等功能。
+

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,130 @@
+const http = require('http');
+const url = require('url');
+
+const port = process.env.PORT || 3000;
+
+// Mock in-memory data
+let courses = [
+  {
+    id: 1,
+    title: 'Node.js Basics',
+    description: 'Introductory Node.js course',
+    start_time: '2025-07-01T10:00:00Z',
+    end_time: '2025-07-01T12:00:00Z',
+    capacity: 30,
+    attendees: 0
+  },
+  {
+    id: 2,
+    title: 'Express Framework',
+    description: 'Building APIs with Express',
+    start_time: '2025-07-02T13:00:00Z',
+    end_time: '2025-07-02T15:00:00Z',
+    capacity: 20,
+    attendees: 0
+  }
+];
+
+const members = {}; // key: line user id -> { id, displayName, email }
+const registrations = []; // { memberId, courseId, status }
+let nextMemberId = 1;
+
+function getOrCreateMember(userId, info) {
+  if (!members[userId]) {
+    members[userId] = { id: nextMemberId++, lineUserId: userId, ...info };
+  }
+  return members[userId];
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk;
+      if (data.length > 1e6) {
+        req.socket.destroy();
+        reject(new Error('request body too large'));
+      }
+    });
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+function sendJSON(res, status, obj) {
+  const data = JSON.stringify(obj);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(data)
+  });
+  res.end(data);
+}
+
+const server = http.createServer(async (req, res) => {
+  const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = parsedUrl.pathname;
+
+  if (req.method === 'GET' && pathname === '/api/courses') {
+    return sendJSON(res, 200, courses);
+  }
+
+  if (req.method === 'POST' && /^\/api\/courses\/(\d+)\/register$/.test(pathname)) {
+    const match = pathname.match(/^\/api\/courses\/(\d+)\/register$/);
+    const courseId = parseInt(match[1], 10);
+    const userId = req.headers['x-user-id'];
+    if (!userId) {
+      return sendJSON(res, 400, { error: 'Missing X-User-Id header' });
+    }
+
+    const course = courses.find(c => c.id === courseId);
+    if (!course) {
+      return sendJSON(res, 404, { error: 'Course not found' });
+    }
+    if (course.attendees >= course.capacity) {
+      return sendJSON(res, 400, { error: 'Course is full' });
+    }
+
+    let body = {};
+    try {
+      body = await parseBody(req);
+    } catch (e) {
+      return sendJSON(res, 400, { error: 'Invalid JSON body' });
+    }
+
+    const member = getOrCreateMember(userId, {
+      displayName: body.displayName || 'LINE User',
+      email: body.email || ''
+    });
+
+    registrations.push({ memberId: member.id, courseId: course.id, status: 'confirmed' });
+    course.attendees += 1;
+
+    return sendJSON(res, 200, { message: 'Registration successful' });
+  }
+
+  if (req.method === 'GET' && pathname === '/api/members/me/registrations') {
+    const userId = req.headers['x-user-id'];
+    if (!userId) {
+      return sendJSON(res, 400, { error: 'Missing X-User-Id header' });
+    }
+
+    const member = members[userId];
+    if (!member) {
+      return sendJSON(res, 200, []);
+    }
+    const myRegs = registrations.filter(r => r.memberId === member.id);
+    return sendJSON(res, 200, myRegs);
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
+});
+
+server.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- drop Express dependency by rewriting the server with Node's built-in `http`
- remove `server/package.json`
- update README to show no installation step needed

## Testing
- `node -c server/index.js`
- `node server/index.js &` *(server started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c6dbc6083328354215e4da8a72f